### PR TITLE
Allow for chained transformations

### DIFF
--- a/Core/AliasGenerator.php
+++ b/Core/AliasGenerator.php
@@ -122,10 +122,17 @@ class AliasGenerator implements VariationService
         if (!empty($fetchPort)) {
             $components['port'] = $fetchPort;
         }
-        $html       = fetch_image_tag(
+        if (!array_key_exists('transformations', $cloudinaryVariationsList[$variationName])) {
+            $transformations = [$cloudinaryVariationsList[$variationName]['filters']];
+        } else {
+            $transformations = $cloudinaryVariationsList[$variationName]['transformations'];
+        }
+
+        $html = cl_image_tag(
             $this->unparseUrl($components),
-            $cloudinaryVariationsList[$variationName]['filters']
+            ["type" => "fetch", "transformation" => $transformations]
         );
+
         $attributes = [];
         foreach ($this->parseAttributes($html) as $key => $value) {
             if ($key == 'img') {


### PR DESCRIPTION
instead of allowing a single filter attribute for image aliases, we add an option for chained transformations, to allow for a normalize -> crop -> scale workflow.

Example configuration to scale a 21:9 image to a 2:1 thumbnail:

```
cloudinary_variations:
  variation_name:
    transformations:
      - secure: 'true'
        crop: 'crop'
        height: 823
        width: 1920
        quality: 'auto:best'
      - crop: 'crop'
        y: 0
        x: 274
        quality: 'auto:best'
      - crop: 'scale'
        height: 210
        aspect_ratio: '2:1'
        quality: 'auto:eco'
```

https://cloudinary.com/documentation/chained_and_named_transformations#chained_transformations